### PR TITLE
Update datatable/index.js

### DIFF
--- a/src/wind/datatable/index.js
+++ b/src/wind/datatable/index.js
@@ -121,10 +121,10 @@ export default {
 
                 // Spacing
                 context?.size === 'small' ? 'py-2.5 px-2' : context?.size === 'large' ? 'py-5 px-4' : 'py-3.5 px-3',
+
                 // Color
-                (props.sortable === '' || props.sortable) && context.sorted ? 'text-primary-500' : 'bg-surface-0 text-surface-700',
-                (props.sortable === '' || props.sortable) && context.sorted ? 'dark:text-primary-400' : 'dark:text-white/80 dark:bg-surface-800',
-                'border-surface-200 dark:border-surface-700 ',
+                (props.sortable === '' || props.sortable) && context.sorted ? 'text-primary-500 dark:text-primary-400' : 'text-surface-700 dark:text-white/80',
+                'bg-surface-0 dark:bg-surface-800 border-surface-200 dark:border-surface-700 ',
 
                 // States
                 'focus-visible:outline-none focus-visible:outline-offset-0 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:focus-visible:ring-primary-400',


### PR DESCRIPTION
Background color is missing when datatable is sortable and a column is sorted

Before:
![simplescreenrecorder-2024-06-06_10 38 03](https://github.com/atakantepe/primevue-tailwind-wind/assets/20279702/6492797d-3b87-4335-accb-be874f8b42b8)


After:
![simplescreenrecorder-2024-06-06_10 38 40](https://github.com/atakantepe/primevue-tailwind-wind/assets/20279702/2a8abaaf-51a8-404f-90cf-bf01cd906951)
